### PR TITLE
use tenant.port from the tenant url parameter (or 443)

### DIFF
--- a/embed-sense-visualizations/config.js
+++ b/embed-sense-visualizations/config.js
@@ -15,7 +15,7 @@ const tenant = new URL(tenantUrl);
 
 module.exports = {
   host: tenant.hostname,
-  port: 443,
+  port: tenant.port || 443,
   isSecure: true,
   prefix: '/',
   webIntegrationId,


### PR DESCRIPTION
If the "tenant" parameter contains a port, use that port. 
(f.ex: tenant=https://elastic.example:32443....) otherwise the example won't work.