### PR TITLE
feat: improve download experience and fix a bug

### DIFF
--- a/embed-sense-visualizations/comm.js
+++ b/embed-sense-visualizations/comm.js
@@ -45,9 +45,27 @@ function getAppList() {
   return _request('/api/v1/items?limit=40').then(_deserialize);
 }
 
+/**
+ * fetching the file represented with the url given in input
+ * @param url
+ * @returns {Promise<Blob>} - result, from Response, a promise that will fulfill with a new Blob object.
+ */
+function getFileContent(url) {
+  return fetch(url, {
+    method: 'GET',
+    mode: 'cors', // cors must be enabled
+    credentials: 'include', // credentials must be included
+    headers: {
+      'Content-Type': 'application/json',
+      'qlik-web-integration-id': webIntegrationId, // needed in order to whitelist your domain
+    }
+  }).then(response => response.blob());
+}
+
 module.exports = {
   getUser,
   getTenant,
   getAppList,
+  getFileContent,
   baseUrl
 };

--- a/embed-sense-visualizations/index.html
+++ b/embed-sense-visualizations/index.html
@@ -58,7 +58,6 @@
             <option value="pdf">PDF</option>
           </select>
           <button id="linechart-download-btn" disabled class="chart-download-button">Download</button>
-          <a id="linechart-download-link" download target="_blank" class="not-visible"> Download Link </a>
           <img id="linechart-download-spinner" src="spinner.gif" class="chart-download-spinner not-visible">
         </div>
         <div id="barchart" tabindex="0" class="chart-padding-container" aria-label="Barchart">

--- a/embed-sense-visualizations/index.js
+++ b/embed-sense-visualizations/index.js
@@ -65,31 +65,25 @@ function renderError(error) {
  * @returns {Promise<void>}
  */
 async function enableLinechartDownload(visualization) {
-  const linechartBoundingClientRect = document.querySelector('#QV01').getBoundingClientRect();
   const linechartDownloadBtn = document.querySelector('#linechart-download-btn');
   const linechartDownloadSelect = document.querySelector('#linechart-select');
-  const linechartDownloadLink = document.querySelector('#linechart-download-link');
   const linechartDownloadSpinner = document.querySelector('#linechart-download-spinner');
   linechartDownloadSelect.disabled = false;
   linechartDownloadSelect.addEventListener('change', async () => {
-    linechartDownloadLink.classList.add('not-visible');
     linechartDownloadSpinner.classList.add('not-visible');
     linechartDownloadBtn.disabled = false;
   });
   linechartDownloadBtn.addEventListener('click', async () => {
-    linechartDownloadLink.classList.add('not-visible');
     linechartDownloadSpinner.classList.remove('not-visible');
     linechartDownloadBtn.disabled = true;
     linechartDownloadSelect.disabled = true;
-
-    const url = await downloadVisualization(
-        visualization,
-        linechartDownloadSelect.value,
-        linechartBoundingClientRect.width,
-        linechartBoundingClientRect.height
+    const linechartBoundingClientRect = document.querySelector('#QV01').getBoundingClientRect();
+    await downloadVisualization(
+      visualization,
+      linechartDownloadSelect.value,
+      linechartBoundingClientRect.width,
+      linechartBoundingClientRect.height
     );
-    linechartDownloadLink.href = url;
-    linechartDownloadLink.classList.remove('not-visible');
     linechartDownloadSpinner.classList.add('not-visible');
     linechartDownloadBtn.disabled = false;
     linechartDownloadSelect.disabled = false;
@@ -149,7 +143,7 @@ async function initMashup() {
 
       vis.show('QV01').then(() => {
         // enable the download button when the chart is ready
-        enableLinechartDownload(vis)
+        enableLinechartDownload(vis);
       });
 
       const vis2 = await app.visualization.get('ced9d474-cad3-4df5-bc09-06d27dcf634a');

--- a/embed-sense-visualizations/package-lock.json
+++ b/embed-sense-visualizations/package-lock.json
@@ -8,6 +8,9 @@
       "name": "plain-mashup",
       "version": "1.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "file-saver": "^2.0.5"
+      },
       "devDependencies": {
         "babel-polyfill": "6.26.0",
         "parcel-bundler": "1.12.5",
@@ -4193,6 +4196,11 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -12246,6 +12254,11 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/embed-sense-visualizations/package.json
+++ b/embed-sense-visualizations/package.json
@@ -12,5 +12,8 @@
     "babel-polyfill": "6.26.0",
     "parcel-bundler": "1.12.5",
     "prettier": "^2.7.1"
+  },
+  "dependencies": {
+    "file-saver": "^2.0.5"
   }
 }

--- a/embed-sense-visualizations/reporting-utils.js
+++ b/embed-sense-visualizations/reporting-utils.js
@@ -1,3 +1,6 @@
+import fileSaver from 'file-saver';
+import comm from './comm';
+
 /**
  * Download the visualization using the Capability APIs - Visualization API
  * https://help.qlik.com/en-US/sense-developer/August2022/Subsystems/APIs/Content/Sense_ClientAPIs/CapabilityAPIs/VisualizationAPI/QVisualization.htm
@@ -6,9 +9,10 @@
  * @param type, can be one of [pdf, image]
  * @param width output width in pixels, default 500
  * @param height output height in pixels, default 400
- * @returns {Promise<string>} the url of the downloaded content
+ * @returns {Promise<void>}
  */
 export const downloadVisualization = (visualization, type, width = 500, height = 400) => {
+  const exportError = () => alert(`Something went wrong, look at the browser console for error details`);
   switch (type) {
     case 'image': {
       const settings = {
@@ -18,8 +22,8 @@ export const downloadVisualization = (visualization, type, width = 500, height =
       };
       return visualization.exportImg(settings).then((result) => {
         console.log(`The image is available at url ${result}`);
-        return result;
-      });
+        downloadFile(result, visualization.id, 'png');
+      }, exportError);
     }
     case 'pdf': {
       const settings = {
@@ -30,8 +34,20 @@ export const downloadVisualization = (visualization, type, width = 500, height =
       };
       return visualization.exportPdf(settings).then((result) => {
         console.log(`The PDF is available at url ${result}`);
-        return result;
-      });
+        downloadFile(result, visualization.id, 'pdf');
+      }, exportError);
     }
   }
+};
+
+const downloadFile = (url, fileName, fileType) => {
+  comm.getFileContent(url).then(
+    (blob) => {
+      const name = fileName ? `${fileName}.${fileType}` : undefined;
+      fileSaver.saveAs(blob, name);
+    },
+    (err) => {
+      alert(`Error saving the file: ${err}`);
+    }
+  );
 };


### PR DESCRIPTION
Improve the download user experience:
Remove one user click by removing the download link; now the download starts automatically when the user clicks on the "download" button (use the filesaver library as sense-client).
Fix a bug: the download link gets out of sync when changing the chart content e.g. by applying some selections.

![Screenshot 2022-10-10 at 09 38 49](https://user-images.githubusercontent.com/10696837/194830519-a7dc9761-0ad3-46f9-9e4d-36d32722ed94.png)
